### PR TITLE
Disable button if no options selected

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,5 +13,6 @@ RoxygenNote: 7.2.1
 Imports: 
     htmltools,
     purrr,
+    stringr,
     uuid,
     yaml

--- a/R/generate_mcq.R
+++ b/R/generate_mcq.R
@@ -7,7 +7,7 @@ generate_mcq <- function(
         "Dortmund" = FALSE
     ),
     button_label = "Check",
-    allow_multiple_answers = TRUE,
+    allow_multiple_answers = FALSE,
     button_id = uuid::UUIDgenerate(),
     radio_buttons_id = uuid::UUIDgenerate()
 ) {
@@ -47,11 +47,29 @@ generate_mcq <- function(
         )
     }
 
-    htmltools::tags$div(
+    # HTML
+    html <- htmltools::tags$div(
         class = "quiz",
         htmltools::tags$div(class = "question", htmltools::HTML(question)),
         purrr::map2(.x = answers, .y = names(answers), add_answer),
         button
     )
+
+    # JavaScript
+    js <- if (allow_multiple_answers) {
+        NULL
+    } else {
+        enable_js <- system.file("enable.js", package = "jsquiz")
+        enable <- paste(readLines(enable_js), collapse = "\n")
+
+        enable <- stringr::str_replace(enable, "options_ids", radio_buttons_id)
+        enable <- stringr::str_replace(enable, "button_id", button_id)
+
+        htmltools::tags$script(
+            htmltools::HTML(enable)
+        )
+    }
+
+    htmltools::tagList(html, js)
 
 }

--- a/R/generate_mcq.R
+++ b/R/generate_mcq.R
@@ -30,7 +30,7 @@ generate_mcq <- function(
             onclick = paste0(
                 "checkAnswer('", button_id, "', '", radio_buttons_id, "');"
             ),
-            diabled = "disabled",
+            disabled = "disabled",
             button_label
         )
     }

--- a/R/generate_mcq.R
+++ b/R/generate_mcq.R
@@ -14,6 +14,27 @@ generate_mcq <- function(
 
     type <- ifelse(allow_multiple_answers, "checkbox", "radio")
 
+    button <- if (allow_multiple_answers) {
+        htmltools::tags$button(
+            class = "check",
+            id = button_id,
+            onclick = paste0(
+                "checkAnswer('", button_id, "', '", radio_buttons_id, "');"
+            ),
+            button_label
+        )
+    } else {
+        htmltools::tags$button(
+            class = "check",
+            id = button_id,
+            onclick = paste0(
+                "checkAnswer('", button_id, "', '", radio_buttons_id, "');"
+            ),
+            diabled = "disabled",
+            button_label
+        )
+    }
+
     add_answer <- function(value, answer) {
         value <- ifelse(value, "true", "false")
         htmltools::tags$label(
@@ -27,22 +48,10 @@ generate_mcq <- function(
     }
 
     htmltools::tags$div(
-
         class = "quiz",
-
         htmltools::tags$div(class = "question", htmltools::HTML(question)),
-
         purrr::map2(.x = answers, .y = names(answers), add_answer),
-
-        htmltools::tags$button(
-            class = "check",
-            id = button_id,
-            onclick = paste0(
-                "checkAnswer('", button_id, "', '", radio_buttons_id, "');"
-            ),
-            button_label
-        )
-
+        button
     )
 
 }

--- a/inst/enable.js
+++ b/inst/enable.js
@@ -1,0 +1,10 @@
+window.addEventListener('DOMContentLoaded', function() {
+    const radioButtons = document.getElementsByName('options_ids');
+    const submitButton = document.getElementById('button_id');
+
+    radioButtons.forEach(function(radioButton) {
+      radioButton.addEventListener('change', function() {
+        submitButton.disabled = false;
+      });
+    });
+});


### PR DESCRIPTION
If we allow for only one correct option, then it makes sense to disable the submit button until an option is selected. It requires adding a JavaScript listener. This listener is added to the body below the question. 